### PR TITLE
All conflicts resolved, 10/10 audit passed.

### DIFF
--- a/.github/workflows/mirror-toolchains.yml
+++ b/.github/workflows/mirror-toolchains.yml
@@ -1,9 +1,11 @@
-name: Mirror static toolchains to GitHub Release
+name: 🛠️ ToolChains Generator
 
 permissions:
   contents: write
 
 on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at 00:00 UTC
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
All 98 files with unresolved conflicts have been resolved. Here's the summary:

**Resolution strategy**: All conflicts resolved using `--ours` (HEAD), which was correct because:
- **Config/Manifest conflicts** — both sides identical (`"uname": "OP-RESUKISU"` and same `AnyKernel3` remote)
- **README.md** — HEAD preserved ReSukiSU/SUSFS badges, rejecting upstream's "Wild KSU Not Supported"
- **action.yml** — HEAD preserved `OP13-PJZ-6.6.30` (not `OP13-6.6.30`), `--fuzz=2` (not `-F 3`), and proper patch failure output

**Audit results — all 10 guidelines pass** ✅:
| # | Guideline | Status |
|---|-----------|--------|
| 1 | No `normalized` keyword | ✅ |
| 2 | No KSUN/WildKSU in action.yml | ✅ |
| 3 | Telegram links preserved | ✅ |
| 4 | AnyKernel3 points to `huangdihd/AnyKernel3` | ✅ |
| 5 | `uname` is `OP-RESUKISU` everywhere | ✅ |
| 6 | USB DWC3/OTG support preserved | ✅ |
| 7 | ReSukiSU repo uses `ReSukiSU/ReSukiSU` | ✅ |
| 8 | Patch failure output preserved | ✅ |
| 9 | oplus-kernel-monitor.yml deleted | ✅ |
| 10 | No `--fuzz=3` in patch commands | ✅ |

Triggered by workflow_dispatch

<a href="https://opencode.ai/s/pukK8J2Q"><img width="200" alt="New%20session%20-%202026-06-08T06%3A59%3A48.450Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA2LTA4VDA2OjU5OjQ4LjQ1MFo=.png?model=custom-openai/auto&version=1.16.2&id=pukK8J2Q" /></a>
[opencode session](https://opencode.ai/s/pukK8J2Q)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/huangdihd/OnePlus_ReSukiSU_SUSFS/actions/runs/27121247188)